### PR TITLE
feat(timer): add `runForward` prop to support stopwatch mode

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -93,6 +93,12 @@ export interface CountDownProps {
    * @default true
    */
   running?: boolean;
+
+  /**
+   * A boolean to support stopwatch mode if true,
+   * @default false
+   */
+  runForward?: boolean;
 }
 
 export interface CountDownState {

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ class CountDown extends React.Component {
     onChange: PropTypes.func,
     onPress: PropTypes.func,
     onFinish: PropTypes.func,
+    runForward: PropTypes.bool,
   };
 
   state = {
@@ -80,7 +81,9 @@ class CountDown extends React.Component {
       const diff = (Date.now() - wentBackgroundAt) / 1000.0;
       this.setState({
         lastUntil: until,
-        until: Math.max(0, until - diff),
+        until: !!this.props?.runForward
+          ? this.state.until + diff
+          : Math.max(0, until - diff),
       });
     }
     if (currentAppState === "background") {
@@ -122,7 +125,9 @@ class CountDown extends React.Component {
       }
       this.setState({
         lastUntil: this.state.until,
-        until: Math.max(0, this.state.until - 1),
+        until: !!this.props?.runForward
+          ? this.state.until + 1
+          : Math.max(0, this.state.until - 1),
       });
     }
   };


### PR DESCRIPTION
Added a new prop runForward to the countdown timer component. When set to true, the timer will count upwards, functioning as a stopwatch, instead of the default countdown (decrementing) behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new option to the timer component allowing it to function as a stopwatch (counting up) when enabled, in addition to the existing countdown mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->